### PR TITLE
DI-18898: Modified CloudViewWidget to only reload  graph instead of whole component

### DIFF
--- a/packages/manager/src/features/CloudView/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/CloudView/Dashboard/Dashboard.tsx
@@ -184,7 +184,7 @@ export const CloudPulseDashboard = React.memo((props: DashboardProperties) => {
         return (
           <Grid columnSpacing={1.5} container rowSpacing={0} spacing={2}>
             {
-                     
+
             {...newDashboard}.widgets.map((element, index) => {
               if (element) {
                 const availMetrics = metricDefinitions?.data.find(
@@ -192,7 +192,7 @@ export const CloudPulseDashboard = React.memo((props: DashboardProperties) => {
                     element.label === availMetrics.label
                 );
                 const cloudViewWidgetProperties = getCloudViewGraphProperties({...element});
-                
+
                 if(availMetrics && !cloudViewWidgetProperties.widget.time_granularity){
                   cloudViewWidgetProperties.widget.time_granularity = getTimeGranularity(availMetrics.scrape_interval);
                 }
@@ -241,7 +241,7 @@ export const CloudPulseDashboard = React.memo((props: DashboardProperties) => {
 
   return (
     <>
-      <RenderWidgets />;
+      <RenderWidgets />
     </>
   );
 });

--- a/packages/manager/src/features/CloudView/Utils/UnitConversion.ts
+++ b/packages/manager/src/features/CloudView/Utils/UnitConversion.ts
@@ -1,4 +1,4 @@
-export type Unit = 'Gb' | 'Kb' | 'Mb' | 'b';
+export type Unit = 'Pb' | 'Tb' | 'Gb' | 'Kb' | 'Mb' | 'b';
 
 /**
  * converts bytes to either Kb (Kilobits) or Mb (Megabits) or Gb (Gigabits)
@@ -10,22 +10,32 @@ export const generateUnitByByteValue = (networkUsedInBytes: number): Unit => {
   const networkUsedToKilobits = (networkUsedInBytes * 8) / 1000;
   if (networkUsedToKilobits <= 1) {
     return 'b';
-  } else if (networkUsedToKilobits <= 1000) {
+  } else if (networkUsedToKilobits <= 1e3) {
     return 'Kb';
-  } else if (networkUsedToKilobits <= 1000000) {
+  } else if (networkUsedToKilobits <= 1e6) {
     return 'Mb';
-  } else {
+  } else if(networkUsedToKilobits <= 1e9) {
     return 'Gb';
+  }else if (networkUsedToKilobits <= 1e12){
+    return 'Tb';
+  }else{
+    return 'Pb';
   }
 };
 
 export const convertBytesToUnit = (valueInBits: number, maxUnit: Unit) => {
-  if (maxUnit === 'Gb') {
-    return valueInBits / Math.pow(1000, 3);
+  if (maxUnit === 'Pb') {
+    return valueInBits / 1e15;
+  }
+  else if (maxUnit === 'Tb') {
+    return valueInBits / 1e12;
+  }
+  else if (maxUnit === 'Gb') {
+    return valueInBits / 1e9;
   } else if (maxUnit === 'Mb') {
-    return valueInBits / Math.pow(1000, 2);
+    return valueInBits / 1e6;
   } else if (maxUnit === 'Kb') {
-    return valueInBits / 1000;
+    return valueInBits / 1e3;
   } else {
     return Math.round(valueInBits);
   }

--- a/packages/manager/src/features/CloudView/Widget/CloudViewLineGraph.tsx
+++ b/packages/manager/src/features/CloudView/Widget/CloudViewLineGraph.tsx
@@ -2,14 +2,12 @@ import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import { makeStyles } from 'tss-react/mui';
 
-import { Divider } from 'src/components/Divider';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import {
   DataSet,
   LineGraph,
   LineGraphProps,
 } from 'src/components/LineGraph/LineGraph';
-import { Typography } from 'src/components/Typography';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   message: {
@@ -17,15 +15,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     position: 'absolute',
     top: '45%',
     transform: 'translate(-50%, -50%)',
-  },
-  title: {
-    '& > span': {
-      color: theme.palette.text.primary,
-    },
-    color: theme.color.headline,
-    fontFamily: theme.font.bold,
-    fontSize: '1rem',
-  },
+  }
 }));
 
 export interface CloudViewLineGraphProps extends LineGraphProps {
@@ -54,19 +44,7 @@ export const CloudViewLineGraph = React.memo(
 
     return (
       <React.Fragment>
-        <Typography
-          className={classes.title}
-          style={{ marginLeft: '13px', marginTop: '25px', paddingTop: '15px' }}
-          variant="body1"
-        >
-          {title}
-          {subtitle && (
-            <React.Fragment>
-              &nbsp;<span>({subtitle})</span>
-            </React.Fragment>
-          )}
-        </Typography>
-        <Divider spacingBottom={32} spacingTop={32} />
+
         <div style={{ position: 'relative' }}>
           {error ? (
             <div style={{ height: props.chartHeight || '300px' }}>

--- a/packages/manager/src/features/CloudView/Widget/CloudViewWidget.tsx
+++ b/packages/manager/src/features/CloudView/Widget/CloudViewWidget.tsx
@@ -423,7 +423,7 @@ export const CloudViewWidget = React.memo(
                 zoomIn={widget?.size == 12 ? true : false}
               />
             </div>
-            <Divider spacingBottom={32} spacingTop={32} />
+            <Divider spacingBottom={32} spacingTop={15} />
             {!isLoading && <CloudViewLineGraph // rename where we have cloudview to cloudpulse
               error={
                 status == 'error'
@@ -441,7 +441,7 @@ export const CloudViewWidget = React.memo(
               data={data}
               formatTooltip={isBytes ? formatToolTip : undefined}
               gridSize={widget.size}
-              legendRows={legendRows}
+              legendRows={(legendRows && legendRows.length > 0) ? legendRows : undefined}
               loading={isLoading}
               nativeLegend={true}
               showToday={today}

--- a/packages/manager/src/features/CloudView/Widget/CloudViewWidget.tsx
+++ b/packages/manager/src/features/CloudView/Widget/CloudViewWidget.tsx
@@ -6,12 +6,14 @@ import {
   TimeGranularity,
   Widgets,
 } from '@linode/api-v4';
-import { Paper } from '@mui/material';
+import { Paper, Theme } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 import React from 'react';
 
 import { CircleProgress } from 'src/components/CircleProgress';
+import { Divider } from 'src/components/Divider';
+import { Typography } from 'src/components/Typography';
 import { CloudPulseResourceTypeMap } from 'src/featureFlags';
 import { useFlags } from 'src/hooks/useFlags';
 import { useCloudViewMetricsQuery } from 'src/queries/cloudview/metrics';
@@ -19,14 +21,13 @@ import { useProfile } from 'src/queries/profile';
 import { isToday as _isToday } from 'src/utilities/isToday';
 import { roundTo } from 'src/utilities/roundTo';
 import { getMetrics } from 'src/utilities/statMetrics';
-
+import { makeStyles } from 'tss-react/mui';
 import {
   AGGREGATE_FUNCTION,
   SIZE,
   TIME_GRANULARITY,
 } from '../Utils/CloudPulseConstants';
 import {
-  convertStringToCamelCasesWithSpaces,
   convertTimeDurationToStartAndEndTimeRange,
   getDimensionName,
 } from '../Utils/CloudPulseUtils';
@@ -71,8 +72,24 @@ const StyledZoomIcon = styled(ZoomIcon, {
   marginTop: '10px',
 });
 
+const useStyles = makeStyles()((theme: Theme) => ({
+
+  title: {
+    '& > span': {
+      color: theme.palette.text.primary,
+    },
+    color: theme.color.headline,
+    fontFamily: theme.font.bold,
+    marginLeft: "8px",
+    fontSize: '1.30rem',
+  },
+}));
+
 export const CloudViewWidget = React.memo(
   (props: CloudViewWidgetProperties) => {
+
+    const { classes } = useStyles();
+
     const { data: profile } = useProfile();
 
     const timezone = profile?.timezone || 'US/Eastern';
@@ -305,7 +322,7 @@ export const CloudViewWidget = React.memo(
     const handleIntervalChange = React.useCallback(
       (intervalValue: TimeGranularity) => {
         if (
-          !widget.time_granularity || 
+          !widget.time_granularity ||
           intervalValue.unit !== widget.time_granularity.unit ||
           intervalValue.value !== widget.time_granularity.value
         ) {
@@ -338,7 +355,7 @@ export const CloudViewWidget = React.memo(
       // todo, add implementation once component is ready
     };
     React.useEffect(() => {
-      if(!props.savePref){
+      if (!props.savePref) {
         return;
       }
       const availableWidget = fetchUserPrefObject()?.widgets[widget.label];
@@ -351,17 +368,6 @@ export const CloudViewWidget = React.memo(
       }
     }, [])
 
-    if (isLoading) {
-      return (
-        <Grid xs={widget.size}>
-          <Paper style={{ height: '98%', width: '100%' }}>
-            <div style={{ margin: '1%' }}>
-              <CircleProgress />
-            </div>
-          </Paper>
-        </Grid>
-      );
-    }
 
     return (
       <Grid xs={widget.size}>
@@ -374,16 +380,21 @@ export const CloudViewWidget = React.memo(
           }}
         >
           {/* add further components like group by resource, aggregate_function, step here , for sample added zoom icon here*/}
-          <div className={widget.metric} style={{ margin: '1%' }}>
+          <div className={widget.metric} style={{ margin: '1%', }}>
             <div
               style={{
-                alignItems: 'start',
+                alignItems: 'center',
                 display: 'flex',
-                float: 'right',
-                justifyContent: 'flex-end',
-                width: '70%',
+                width: '100%',
               }}
             >
+              <Grid sx={{ marginRight: "auto" }}>
+                <Typography
+                  className={classes.title}
+                >
+                  {`${props.widget.label}`} {(!isLoading || !isBytes) && `(${currentUnit})`} {/* show the units of bytes data only when complete data is loaded */}
+                </Typography>
+              </Grid>
               <Grid sx={{ marginRight: 5, width: 100 }}>
                 {props.availableMetrics?.scrape_interval && (
                   <IntervalSelectComponent
@@ -412,7 +423,8 @@ export const CloudViewWidget = React.memo(
                 zoomIn={widget?.size == 12 ? true : false}
               />
             </div>
-            <CloudViewLineGraph // rename where we have cloudview to cloudpulse
+            <Divider spacingBottom={32} spacingTop={32} />
+            {!isLoading && <CloudViewLineGraph // rename where we have cloudview to cloudpulse
               error={
                 status == 'error'
                   ? error && error.length > 0
@@ -433,11 +445,12 @@ export const CloudViewWidget = React.memo(
               loading={isLoading}
               nativeLegend={true}
               showToday={today}
-              subtitle={currentUnit}
               timezone={timezone}
-              title={convertStringToCamelCasesWithSpaces(props.widget.label)}
+              title={""}
               unit={!isBytes ? ` ${currentUnit}` : undefined}
-            />
+            />}
+            {isLoading &&
+              <CircleProgress />}
           </div>
         </Paper>
       </Grid>


### PR DESCRIPTION
1. Modified widget component to only show loading on graphs if any of the parameters changed and not on complete widget component.
2. Added Tb (Tera bits) & Pb (Peta bits) support on data scaling of graph

![Screenshot 2024-06-20 at 1 07 48 PM](https://github.com/venkymano/manager/assets/165884194/15146c95-c463-4e3e-85fc-dc1ff8010076)
![Screenshot 2024-06-20 at 1 08 27 PM](https://github.com/venkymano/manager/assets/165884194/6b540494-ac8e-4c22-8e13-3825ffe1b5cd)
